### PR TITLE
Propose une nouvelle présentation des cards

### DIFF
--- a/main/static/main.css
+++ b/main/static/main.css
@@ -26,3 +26,19 @@ a .ellipsis:after {
 .neg-tiny-top-space {
     margin-top: -10px;
 }
+.description {
+    font-style: italic;
+}
+
+.card {
+    width: 400px;
+    margin: 2rem;
+}
+.card-img-top {
+    overflow:hidden;
+    height: 14rem;
+}
+img {
+    width: 400px;
+    clip-path: content-box;
+}

--- a/main/static/main.css
+++ b/main/static/main.css
@@ -34,6 +34,9 @@ a .ellipsis:after {
     width: 400px;
     margin: 2rem;
 }
+.cards {
+    justify-content: left;
+}
 .card-img-top {
     overflow:hidden;
     height: 14rem;

--- a/main/templates/submit_toot.html
+++ b/main/templates/submit_toot.html
@@ -38,7 +38,8 @@
 		</ul>
 	    </div>
 	    <div class="row neg-tiny-top-space">
-		Les titres et images sont générés automatiquement.
+		Les titres, images et description sont générés automatiquement quand le
+		site le supporte.
 	    </div>
 	    <div class="row small-top-space">
 		<h2>Poster une émission</h2>
@@ -59,19 +60,30 @@
 	    </div>
 	    <div class="row">
 		{% for toot in toot_list %}
-		<div class="card" style="width: 32rem; margin: 1rem">
-
-		    <div class="card-img-top" style="overflow:hidden; height: 14rem">
-			<img style="width: 32rem; clip-path: content-box;" src="{{ toot.image | safe}}">
+		<div class="card">
+		    <div class="card-img-top">
+			    <img  src="{{ toot.image | safe}}">
 		    </div>
+            {% if toot.card.title or toot.card.description %}
 		    <div class="card-body">
-			<h5 class="card-title">
-			    {{ toot.title | safe}}
-			</h5>
-			<p class="card-text" >
-			    {{ toot.content | safe}}
-			</p>
-		    </div>
+                {% if toot.card.title %}
+			    <h5 class="card-title">
+			        {{ toot.card.title | safe}}
+			    </h5>
+                {% endif %}
+                {% if toot.card.description %}
+			    <div class="card-text" >
+               {{ toot.card.description }}
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+		    <div class="card-body bg-light">
+			    </p>
+                <div class="card-text description">
+                    {{ toot.content | safe}}
+                </div>
+            </div>
 		</div>
 		{% endfor %}
 	    </div>

--- a/main/templates/submit_toot.html
+++ b/main/templates/submit_toot.html
@@ -54,7 +54,7 @@
 	    <div class="row top-space">
 		<h2>Les 20 dernières émissions postées</h2>
 	    </div>
-	    <div class="row">
+	    <div class="row cards" >
 		L'intégrale des émissions proposée est disponible ici :&nbsp;
 		<a href="https://toot.aquilenet.fr/@oreille_gauche">https://toot.aquilenet.fr/@oreille_gauche</a>
 	    </div>

--- a/main/views.py
+++ b/main/views.py
@@ -28,8 +28,8 @@ class TootForm(forms.Form):
 def content_of_toot(t):
     d = {'content': t['content']}
     if t['card'] is not None:
+        d['card'] = t['card']
         d['image'] = t['card']['image']
-        d['title'] = t['card']['title']
     else:
         d['image'] = static('default_card_image.jpg')
     return d


### PR DESCRIPTION
- mentionne la description lorsqu'elle est fournie
- à la largeur native des images (400px), évite l'overscaling moche
- règles CSS déplacée dans feuille de style

Capture d'écran : 
![image](https://user-images.githubusercontent.com/429633/68814959-59c3c380-067a-11ea-893a-f56a066945e0.png)
